### PR TITLE
Catch up with upstream

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -814,11 +814,11 @@ module.exports = function (grunt) {
     'unicode',
     'concat',
     'uglify',
-    'less',
+    // 'less',
     'copy',
     'clean:release',
-    'moxiezip',
-    'nugetpack',
+    // 'moxiezip',
+    // 'nugetpack',
     'version'
   ]);
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,14 @@
 TinyMCE - JavaScript Library for Rich Text Editing
 ===================================================
 
+TX flow
+---------
+* Start with "Building TinyMCE" section
+* When you need to contribute, use `grunt start` and use the demos to develop and test features
+* Use `grunt bundle --plugins=noneditable,paste` in the root tinymce folder
+* Copy `tinymce/js/tinymce/tinymce.full.min.js` to the folder we keep our editor
+
+
 Building TinyMCE
 -----------------
 Install [Node.js](https://nodejs.org/en/) on your system.

--- a/src/core/demo/css/content_editable.css
+++ b/src/core/demo/css/content_editable.css
@@ -31,17 +31,3 @@
   outline: 2px solid blue;
 }
 
-.mce-content-body .mce-offscreen-selection {
-  left: auto;
-  right: 0;
-}
-
-*[data-mce-caret] {
-  outline: 1px solid green;
-  position: absolute;
-  left: auto;
-  right: 0;
-  top: 0;
-  margin: 0;
-  padding: 0;
-}

--- a/src/core/demo/html/rtl_cef.html
+++ b/src/core/demo/html/rtl_cef.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Tinymce RTL CEF demo Page</title>
+  </head>
+
+  <body>
+  <h2>Tinymce content editable false Page</h2>
+    <div style="width:50%;margin: 0 auto">
+      <h4>LTR content with LTR direction</h4>
+      <div id="ephox-ui">
+        <div id="tinymce1" style="width: 80%">
+          bla <span contentEditable="false" style="width:20px" dir="ltr" >%(hello)s</span> pla plap lapslf,apsdlfk aspdofk aspdofk
+          asd
+        </div>
+      </div>
+
+      <h4>BIDI content with LTR direction</h4>
+      <div id="ephox-ui">
+        <div id="tinymce2" style="width: 80%">
+          bla الصناعة على الشبكة العالمية انترنيت <span contentEditable="false" style="width:20px" dir="ltr" >%(hello)s</span> pla  الصناعة على الشبكة العالمية انترنيت plap lapslf,apsdlfk aspdofk aspdofk
+          asd
+        </div>
+      </div>
+
+      <!-- dir should be changed by hand to see the correct behaviour since tinymce add dynamicaly the attribute -->
+      <h4>RTL content with LTR direction</h4>
+      <div id="ephox-ui">
+        <div id="tinymce4" style="width: 80%" dir="ltr">
+          طاعات الصناعة على الشبكة العالمية انترنيت <span contentEditable="false" style="width:20px" dir="ltr">%(hello)s</span> ويونيكود، حيث ستتم، على الصعيدين الدولي والمحلي على حد سواء مناقشة سبل استخدام يونكود في النظم القائمة وفيما ي
+        </div>
+      </div>
+
+      <h4>RTL content with RTL direction</h4>
+      <div id="ephox-ui">
+        <div id="tinymce5" style="width: 80%" dir="rtl">
+          طاعات الصناعة على<span contenteditable="true" dir="ltr">%(pla)s</span> الشبكة العالمية انترنيت <span contentEditable="false" style="width:20px" dir="ltr">%(hello)s</span> ويونيكود، حيث ستتم، على الصعيدين الدولي والمحلي على حد سواء مناقشة سبل استخدام يونكود في النظم القائمة وفيما ي
+          asd
+        </div>
+      </div>
+
+      <h4>BIDI content with RTL direction <span class="issue">ISSUE</span></h4>
+      <div id="ephox-ui">
+        <div id="tinymce3" style="width: 80%">
+          bla الصناعة على الشبكة العالمية انترنيت LTR_CONTENT<span contentEditable="false" style="width:20px" dir="ltr" >%(hello)s</span>LTR_CONTENT pla  الصناعة على الشبكة العالمية انترنيت plap lapslf,apsdlfk aspdofk aspdofk
+        </div>
+      </div>
+    </div>
+    <script src="../../../../js/tinymce/tinymce.js"></script>
+    <script src="../../../../scratch/demos/core/demo.js"></script>
+    <script>demos.ContentEditableFalseDemo();</script>
+  </body>
+</html>

--- a/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
+++ b/src/core/demo/ts/demo/ContentEditableFalseDemo.ts
@@ -1,5 +1,5 @@
 // tslint:disable:no-console
-import { console } from '@ephox/dom-globals';
+import { console, document } from '@ephox/dom-globals';
 import Editor from 'tinymce/core/api/Editor';
 
 declare const window: any;
@@ -62,26 +62,113 @@ export default function () {
   window.logPos = logPos;
 
   tinymce.init({
-    selector: 'textarea.tinymce',
-    skin_url: '../../../../js/tinymce/skins/ui/oxide',
-    add_unload_trigger: false,
-    toolbar: 'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify' +
-    ' | bullist numlist outdent indent | link image | print preview media fullpage | forecolor backcolor emoticons table codesample',
-    plugins: ['paste', 'list'],
+    selector: '#tinymce1',
+    toolbar: false,
+    statusbar: false,
+    menubar: false,
+    skin: false,
+    plugins: 'paste noneditable',
+    paste_as_text: true,
+    smart_paste: false,
+    theme: false,
+    forced_root_block: false,
+    root_block: 'div',
+    inline: true,
+    visual: false,
+    browser_spellcheck: true,
     content_css: '../css/content_editable.css',
-    height: 400
+    height: 400,
   });
 
   tinymce.init({
-    selector: 'div.tinymce',
+    selector: '#tinymce2',
+    toolbar: false,
+    statusbar: false,
+    menubar: false,
+    skin: false,
+    plugins: 'paste noneditable',
+    paste_as_text: true,
+    smart_paste: false,
+    theme: false,
+    forced_root_block: false,
+    root_block: 'div',
     inline: true,
-    skin_url: '../../../../js/tinymce/skins/ui/oxide',
-    add_unload_trigger: false,
-    toolbar: 'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify' +
-    ' | bullist numlist outdent indent | link image | print preview media fullpage | forecolor backcolor emoticons table codesample',
-    plugins: ['paste', 'list'],
-    content_css: '../css/content_editable.css'
+    visual: false,
+    browser_spellcheck: true,
+    content_css: '../css/content_editable.css',
+    // directionality: 'rtl',
+    // force_rtl: true,
+  });
+  tinymce.init({
+    selector: '#tinymce3',
+    toolbar: false,
+    statusbar: false,
+    menubar: false,
+    skin: false,
+    plugins: 'paste noneditable',
+    paste_as_text: true,
+    smart_paste: false,
+    theme: false,
+    forced_root_block: false,
+    root_block: 'div',
+    inline: true,
+    visual: false,
+    browser_spellcheck: true,
+    content_css: '../css/content_editable.css',
+    directionality: 'rtl',
   });
 
+  tinymce.init({
+    selector: '#tinymce4',
+    toolbar: false,
+    statusbar: false,
+    menubar: false,
+    skin: false,
+    plugins: 'paste noneditable',
+    paste_as_text: true,
+    smart_paste: false,
+    theme: false,
+    forced_root_block: false,
+    root_block: 'div',
+    inline: true,
+    visual: false,
+    browser_spellcheck: true,
+    content_css: '../css/content_editable.css',
+    directionality: 'ltr'
+  });
+
+  tinymce.init({
+    selector: '#tinymce5',
+    toolbar: false,
+    statusbar: false,
+    menubar: false,
+    skin: false,
+    plugins: 'paste noneditable',
+    paste_as_text: true,
+    smart_paste: false,
+    theme: false,
+    forced_root_block: false,
+    root_block: 'div',
+    inline: true,
+    visual: false,
+    browser_spellcheck: true,
+    content_css: '../css/content_editable.css',
+    directionality: 'rtl'
+  });
+
+  const button = document.createElement('button');
+  button.innerHTML = 'Toggle Directionality';
+  button.addEventListener('click', () => {
+    const c = tinymce.activeEditor.settings.directionality;
+    if (c === 'rtl') {
+      tinymce.activeEditor.settings.directionality = 'ltr';
+    } else {
+      tinymce.activeEditor.settings.directionality = 'rtl';
+    }
+    // tslint:disable no-console
+    console.log(tinymce.activeEditor.settings.directionality);
+    // tslint:enable no-console
+  });
+  document.body.appendChild(button);
   window.tinymce = tinymce;
 }

--- a/src/core/main/ts/api/Settings.ts
+++ b/src/core/main/ts/api/Settings.ts
@@ -67,6 +67,11 @@ const getForcedRootBlock = (editor: Editor): string => {
   }
 };
 
+const getRootBlock = (editor: Editor): string => {
+  const block = editor.getParam('root_block', 'div');
+  return block;
+};
+
 const getForcedRootBlockAttrs = (editor: Editor): Record<string, string> => {
   return editor.getParam('forced_root_block_attrs', {});
 };
@@ -201,5 +206,6 @@ export default {
   shouldIndentUseMargin,
   getIndentation,
   getContentCss,
-  getDirectionality
+  getDirectionality,
+  getRootBlock,
 };

--- a/src/core/main/ts/api/SettingsTypes.ts
+++ b/src/core/main/ts/api/SettingsTypes.ts
@@ -86,6 +86,7 @@ export interface RawEditorSettings {
   fontsize_formats?: string;
   force_hex_style_colors?: boolean;
   forced_root_block?: boolean | string;
+  root_block?: string | '';
   forced_root_block_attrs?: Record<string, string>;
   formats?: Formats;
   gecko_spellcheck?: boolean;

--- a/src/core/main/ts/content/SetContent.ts
+++ b/src/core/main/ts/content/SetContent.ts
@@ -63,7 +63,7 @@ const setContentString = (editor: Editor, body: HTMLElement, content: string, ar
       content = '<li>' + padd + '</li>';
     }
 
-    forcedRootBlockName = Settings.getForcedRootBlock(editor);
+    forcedRootBlockName = Settings.getRootBlock(editor);
 
     // Check if forcedRootBlock is configured and that the block is a valid child of the body
     if (forcedRootBlockName && editor.schema.isValidChild(body.nodeName.toLowerCase(), forcedRootBlockName.toLowerCase())) {

--- a/src/core/main/ts/keyboard/FormatShortcuts.ts
+++ b/src/core/main/ts/keyboard/FormatShortcuts.ts
@@ -8,18 +8,18 @@ import Editor from '../api/Editor';
 
 const setup = function (editor: Editor) {
   // Add some inline shortcuts
-  editor.addShortcut('meta+b', '', 'Bold');
-  editor.addShortcut('meta+i', '', 'Italic');
-  editor.addShortcut('meta+u', '', 'Underline');
+  // editor.addShortcut('meta+b', '', 'Bold');
+  // editor.addShortcut('meta+i', '', 'Italic');
+  // editor.addShortcut('meta+u', '', 'Underline');
 
-  // BlockFormat shortcuts keys
-  for (let i = 1; i <= 6; i++) {
-    editor.addShortcut('access+' + i, '', ['FormatBlock', false, 'h' + i]);
-  }
+  // // BlockFormat shortcuts keys
+  // for (let i = 1; i <= 6; i++) {
+  //   editor.addShortcut('access+' + i, '', ['FormatBlock', false, 'h' + i]);
+  // }
 
-  editor.addShortcut('access+7', '', ['FormatBlock', false, 'p']);
-  editor.addShortcut('access+8', '', ['FormatBlock', false, 'div']);
-  editor.addShortcut('access+9', '', ['FormatBlock', false, 'address']);
+  // editor.addShortcut('access+7', '', ['FormatBlock', false, 'p']);
+  // editor.addShortcut('access+8', '', ['FormatBlock', false, 'div']);
+  // editor.addShortcut('access+9', '', ['FormatBlock', false, 'address']);
 };
 
 export default {


### PR DESCRIPTION
Updated tinymce to support our use case:

 * Remove format shortcuts
 * Add root block for the editor "root_block" setting which is added
   when the editor is empty
 * Inverse key navigation on cef when directionality = rtl. This is a
   hacky way. We need to reconsider.
 * Add usage to readme
